### PR TITLE
Trim expected md5 so screenshot test works on Ubuntu

### DIFF
--- a/clean-previous.js
+++ b/clean-previous.js
@@ -11,7 +11,7 @@ killChrome = platform.isWindows() ? "taskkill /f /im chrome.exe" : "pkill -f chr
 killInstaller = platform.isWindows() ? "taskkill /f /im installer" : "pkill -f installer";
 
 module.exports = function* cleanPreviousRun() {
-  yield platform.killJava();
+  try { platform.killJava(); } catch(err){}
   try {execSync(killChrome);} catch (err){}
   try {execSync(killInstaller);} catch (err){}
   yield platform.deleteRecursively(platform.getInstallDir());

--- a/e2e-tests/install-and-upgrade.js
+++ b/e2e-tests/install-and-upgrade.js
@@ -10,7 +10,8 @@ module.exports = function*(version) {
   log.debug(`Using bundle version ${version}`);
   yield cleanPrevious;
 
-  yield downloader.downloadInstaller(version, this).catch((err)=>{this.throw(err);});
+  yield downloader.downloadInstaller(version, this)
+    .catch((err)=>this.throw(err));
 
   yield platform.setFilePermissions(downloader.getDownloadedInstallerFilePath(), 0755);
 

--- a/presentation.js
+++ b/presentation.js
@@ -1,9 +1,13 @@
-var execSync = require("child_process").execSync,
+var fs = require("fs"),
+execSync = require("child_process").execSync,
 os = process.platform === "linux" ? "lnx" : "win",
-expectedMd5 = require("fs").readFileSync("expected-md5.txt", {encoding: "utf8"}),
 md5Cmd = (os === "lnx" ? "md5sum screen.png" : "certUtil -hashfile screen.png MD5"),
 screenshotCmd = (os === "lnx" ? "scrot screen.png" : "nircmd.exe savescreenshot screen.png"),
-cmdOpts = {cwd:__dirname, encoding: "utf8"};
+cmdOpts = {cwd:__dirname, encoding: "utf8"},
+expectedMd5 = fs.readFileSync("expected-md5.txt", {encoding: "utf8"});
+
+// Trim last character. Without this, the screenshot test fails on Ubuntu
+expectedMd5 = expectedMd5.slice(0, expectedMd5.length - 1);
 
 function checkScreen() {
   log.debug("taking screenshot");
@@ -16,7 +20,7 @@ module.exports = {
     return new Promise((res)=>{
       ctx.timeouts.presentation = setTimeout(()=>{
         if (checkScreen()) {return res();}
-        res(module.exports.confirmPresentationVisibility(ctx));
+        return res(module.exports.confirmPresentationVisibility(ctx));
       }, 5000);
     });
   }


### PR DESCRIPTION
Also throw an Error object

@tejohnso @fjvallarino The screenshot test was failing on Ubuntu, and this is the easiest way I can think of to fix it. If you have any other ideas, feel free to share them