### PR TITLE
Allow multiple potential screenshot checksums

### DIFF
--- a/presentation.js
+++ b/presentation.js
@@ -1,14 +1,18 @@
 var execSync = require("child_process").execSync,
 os = process.platform === "linux" ? "lnx" : "win",
-expectedMd5 = require("fs").readFileSync("expected-md5.txt", {encoding: "utf8"}),
+fs = require("fs"),
+expectedMd5 = fs.readFileSync("expected-md5.txt", {encoding: "utf8"})
+.split(/[^a-zA-Z0-9 ]/).filter(el=>el),
 md5Cmd = (os === "lnx" ? "md5sum screen.png" : "certUtil -hashfile screen.png MD5"),
 screenshotCmd = (os === "lnx" ? "scrot screen.png" : "nircmd.exe savescreenshot screen.png"),
 cmdOpts = {cwd:__dirname, encoding: "utf8"};
 
 function checkScreen() {
+  var md5;
   log.debug("taking screenshot");
   execSync(screenshotCmd, cmdOpts);
-  return (execSync(md5Cmd, cmdOpts).indexOf(expectedMd5) > -1);
+  md5 = execSync(md5Cmd, cmdOpts);
+  return expectedMd5.some((expected)=>{return md5.includes(expected);});
 }
 
 module.exports = {


### PR DESCRIPTION
If a version uses a slightly different rendering engine it might produce
a different screenshot checksum.  It should be added to the
expected-md5.txt file so that either one passes.

@ahmedalsudani this should also fix your last character issue
@fjvallarino fyi