### PR TITLE
Update Rise Cache test

### DIFF
--- a/cache-check.js
+++ b/cache-check.js
@@ -8,7 +8,7 @@ function pingCache() {
   .then((data)=>{
     return data.name === "rise-cache-v2";
   })
-  .catch((err)=>{return false;});
+  .catch(()=>{return false;});
 }
 
 module.exports = function cacheCheck(ctx) {
@@ -23,4 +23,4 @@ module.exports = function cacheCheck(ctx) {
       }, 5000);
     });
   });
-}
+};

--- a/cache-check.js
+++ b/cache-check.js
@@ -1,12 +1,12 @@
 const network = require("rise-common-electron").network;
 
 function pingCache() {
-  return network.httpFetch("http://localhost:9494/ping?callback=cb")
+  return network.httpFetch("http://localhost:9494/")
   .then((resp)=>{
-    return resp.text();
+    return resp.json();
   })
-  .then((text)=>{
-    return (text === "cb();");
+  .then((data)=>{
+    return data.name === "rise-cache-v2";
   })
   .catch((err)=>{return false;});
 }


### PR DESCRIPTION
Rise Cache v2 does not provide a /ping endpoint. The / endpoint should be used, which returns json information about the running instance.

@tejohnso please review
