### PR TITLE
Don't create two connections per test

### DIFF
--- a/utils/messaging.js
+++ b/utils/messaging.js
@@ -31,7 +31,7 @@ function createConnection(url, displayId) {
           parser: "json"
         });
 
-        connection = new Socket(url + (displayId ? "&displayId=" + displayId : ""));
+        connection = new Socket(url + (displayId ? "&displayId=" + displayId : ""), {manual: true});
 
         connection.on("data", (data)=>{
           if(data.msg === "client-connected" && !displayId) {
@@ -53,7 +53,6 @@ function createConnection(url, displayId) {
             res();
           }
         });
-
 
         console.log("Opening connection");
 


### PR DESCRIPTION
A hidden connection is created by new Socket()
It automatically connects.  So the open() call creates a second
connection.  Specifying {manual:true} corrects that.

Optionally, {manual:true} can be left out and the call to open() can be
removed.  That way we'd rely on the implicit (hidden) connection from
new Socket().  I prefer to keep the connection open explicit so that one
doesn't have to wonder whether the callbacks have time to be registered
before the implicit connection is opened.  Looking at the source, they
do have time via a setTimeout for the implicit open() call but one
wouldn't know that by looking at the client code.