### PR TITLE
support beta player

### DIFF
--- a/downloader.js
+++ b/downloader.js
@@ -5,7 +5,9 @@ fileSuffix = (os === "lnx" ? "sh" : "exe"),
 downloadedInstallerFileName = "installer." + fileSuffix,
 arch = process.arch === "x64" ? "64" : (process.arch === "arm" ? "arm" : "32"),
 baseUrl = "http://install-versions.risevision.com/",
+baseUrlBeta = `${baseUrl}beta/`,
 configFile = "display-modules",
+configFileBeta = `${configFile}-beta`,
 http = require("http"),
 https = require("https"),
 fs = require("fs");
@@ -46,9 +48,15 @@ module.exports = {
       return resp.json();
     });
   },
+  getRemoteBetaManifest() {
+    return network.httpFetch(`${baseUrlBeta}${configFileBeta}-${os}-${arch}.json`)
+    .then((resp)=>{
+      return resp.json();
+    });
+  },
   getExpectedScreenshot(screenshotUrl, format = "png") {
     const file = fs.createWriteStream(expectedScreenshotFile+format);
-    
+
     return new Promise((res, rej)=>{
       const fn = screenshotUrl.startsWith("https") ? https : http;
 
@@ -68,6 +76,6 @@ module.exports = {
         })
         .on("error", (err)=>{console.dir(err); rej(err);});
       });
-    }); 
+    });
   }
 };

--- a/test-display-runner.js
+++ b/test-display-runner.js
@@ -2,17 +2,23 @@ global.log = console;
 const displayId = process.argv[2];
 const presentationScreenshotUrl = process.argv[3];
 const numberOfPrints = process.argv[4];
+const rolloutEnvironment = process.argv[5] || "stable";
 
 const downloader = require("./downloader.js");
 const presentation = require("./presentation.js");
 const platform = require("rise-common-electron").platform;
 const installerStarter = require("./installer-starter.js");
 
+const getManifest = function () {
+  return rolloutEnvironment === "beta" ?
+    downloader.getRemoteBetaManifest() : downloader.getRemoteManifest();
+}
+
 const testDisplay = function () {
   const ctx = {timeouts: {presentation: null}};
   console.log(`Arguments: ${displayId} ${presentationScreenshotUrl}`);
   let remoteManifest = "";
-  downloader.getRemoteManifest()
+  getManifest()
   .then((res)=>{
     remoteManifest = res;
     downloader.downloadInstaller(remoteManifest)
@@ -26,7 +32,7 @@ const testDisplay = function () {
               .then(()=>{
                 console.log("Success")
                 process.exit();
-              }) 
+              })
               .catch((err)=>{
                 console.log("Test error");
                 process.exit(1);
@@ -40,4 +46,3 @@ const testDisplay = function () {
   });
 }
 testDisplay();
-


### PR DESCRIPTION
This change will allow content tests using test-display-runner.js to choose if they are being run using beta or stable electron player, as currently stable player is the one being used.

Selection is performed via an extra optional argument to the script that defaults to "stable".

Manually tested using this branch, check the CCI job here:
    https://circleci.com/gh/Rise-Vision/rise-data-image/487
