### PR TITLE
add script that runs e2e test on previously downloaded installer and …

### DIFF
--- a/test-display-runner-using-downloaded-installer.js
+++ b/test-display-runner-using-downloaded-installer.js
@@ -1,0 +1,29 @@
+global.log = console;
+const displayId = process.argv[2];
+const numberOfPrints = process.argv[3];
+
+const presentation = require("./presentation");
+const installerStarter = require("./installer-starter");
+
+const testDisplay = function () {
+  const ctx = {timeouts: {presentation: null}};
+  console.log(`Argument: ${displayId}`);
+
+  Promise.resolve().then(()=>{
+    installerStarter.startDownloadedInstaller();
+    presentation.confirmPresentationVisibility(ctx, "jpg", numberOfPrints)
+    .then(()=>{
+      console.log("Success")
+      process.exit();
+    })
+    .catch((err)=>{
+      console.log("Test error");
+      process.exit(1);
+    });
+  })
+  .catch((err)=>{
+    console.log("installer start error " + require("util").inspect(err));
+    process.exit(1);
+  });
+}
+testDisplay();


### PR DESCRIPTION
Simplified version of the script that only runs the test.

I left the old script there because twitter-module still uses it, but if we have problems with that also we can change it to this.
