### PR TITLE
Fix common-template/components e2e test

### DIFF
--- a/test-display-runner-using-downloaded-installer.js
+++ b/test-display-runner-using-downloaded-installer.js
@@ -11,7 +11,10 @@ const presentation = require("./presentation");
 const installerStarter = require("./installer-starter");
 
 const preparePlayerModule = function () {
-  try {fs.mkdirSync(path.join(launcherUtils.getInstallDir(), "modules", "player-electron"));} catch(err) {};
+  const playerModulePath = path.join(launcherUtils.getInstallDir(), "modules", "player-electron");
+  if (!fs.existsSync(playerModulePath)) {
+    fs.mkdirSync(playerModulePath);
+  }
   const compatFilePath = path.join(launcherUtils.getInstallDir(), "modules", "player-electron", "electron-compat.txt");
   return platform.writeTextFile(compatFilePath, "v1\nv2\nv3\nv4\n");
 }

--- a/test-display-runner-using-downloaded-installer.js
+++ b/test-display-runner-using-downloaded-installer.js
@@ -2,16 +2,28 @@ global.log = console;
 const displayId = process.argv[2];
 const numberOfPrints = process.argv[3];
 
+const platform = require("rise-common-electron").platform;
+const path = require("path");
+const fs = require("fs");
+
+const launcherUtils = require("./utils/launcher-utils.js");
 const presentation = require("./presentation");
 const installerStarter = require("./installer-starter");
 
+const preparePlayerModule = function () {
+  try {fs.mkdirSync(path.join(launcherUtils.getInstallDir(), "modules", "player-electron"));} catch(err) {};
+  const compatFilePath = path.join(launcherUtils.getInstallDir(), "modules", "player-electron", "electron-compat.txt");
+  return platform.writeTextFile(compatFilePath, "v1\nv2\nv3\nv4\n");
+}
+
 const testDisplay = function () {
   const ctx = {timeouts: {presentation: null}};
-  console.log(`Argument: ${displayId}`);
+  console.log(`Arguments: ${displayId} ${numberOfPrints}`);
 
-  Promise.resolve().then(()=>{
-    installerStarter.startDownloadedInstaller();
-    presentation.confirmPresentationVisibility(ctx, "jpg", numberOfPrints)
+  preparePlayerModule()
+    .then(()=>{
+      installerStarter.startDownloadedInstaller();
+      presentation.confirmPresentationVisibility(ctx, "jpg", numberOfPrints)
     .then(()=>{
       console.log("Success")
       process.exit();

--- a/test-display-runner-using-downloaded-installer.js
+++ b/test-display-runner-using-downloaded-installer.js
@@ -15,7 +15,7 @@ const preparePlayerModule = function () {
   if (!fs.existsSync(playerModulePath)) {
     fs.mkdirSync(playerModulePath);
   }
-  const compatFilePath = path.join(launcherUtils.getInstallDir(), "modules", "player-electron", "electron-compat.txt");
+  const compatFilePath = path.join(playerModulePath, "electron-compat.txt");
   return platform.writeTextFile(compatFilePath, "v1\nv2\nv3\nv4\n");
 }
 


### PR DESCRIPTION
## Description
Create required electron-compat.txt before starting installer on e2e test script

## Motivation and Context
The e2e tests for `common-template` and components started failing after we upgraded electron on `rise-launcher-electron`. The new version requires an existing electron-compat.txt file in the player module directory. 

## How Has This Been Tested?
Tested running the script locally, but I need to merge this to effectively test the e2e tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
