### PR TITLE
Use ensureDir

### DIFF
--- a/test-display-runner-using-downloaded-installer.js
+++ b/test-display-runner-using-downloaded-installer.js
@@ -4,7 +4,7 @@ const numberOfPrints = process.argv[3];
 
 const platform = require("rise-common-electron").platform;
 const path = require("path");
-const fs = require("fs");
+const fs = require("fs-extra");
 
 const launcherUtils = require("./utils/launcher-utils.js");
 const presentation = require("./presentation");
@@ -12,9 +12,7 @@ const installerStarter = require("./installer-starter");
 
 const preparePlayerModule = function () {
   const playerModulePath = path.join(launcherUtils.getInstallDir(), "modules", "player-electron");
-  if (!fs.existsSync(playerModulePath)) {
-    fs.mkdirSync(playerModulePath, { recursive: true });
-  }
+  fs.ensureDirSync(playerModulePath);
   const compatFilePath = path.join(playerModulePath, "electron-compat.txt");
   return platform.writeTextFile(compatFilePath, "v1\nv2\nv3\nv4\n");
 }


### PR DESCRIPTION
## Description
Fix test script

## Motivation and Context
The e2e tests for common-template and components started failing after we upgraded electron on rise-launcher-electron. The new version requires an existing electron-compat.txt file in the player module directory.

## How Has This Been Tested?
Tested running the script locally, but I need to merge this to effectively test the e2e tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed